### PR TITLE
fix: Remove david dependency bad

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,6 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://david-dm.org/ayonious/console-table-printer">
-    <img alt="dependencies Status" src="https://david-dm.org/ayonious/console-table-printer/status.svg">
-  </a>
-  <a href="https://david-dm.org/ayonious/console-table-printer?type=dev">
-    <img alt="devDependencies Status" src="https://david-dm.org/ayonious/console-table-printer/dev-status.svg">
-  </a>
-</p>
-<p align="center">
   <a href="https://github.com/prettier/prettier">
     <img alt="code style: prettier" src="https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=plastic">
   </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "console-table-printer",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "console-table-printer",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "repository": "github:ayonious/console-table-printer",
   "description": "Printing pretty tables on console log",
   "main": "dist/index.js",


### PR DESCRIPTION
## 👀What is this pr about?

Removing david tags from readme

## 🚀Changes

### Fixed

- [x] badges from David to show dependencies status was constantly causing getting errors. So removed them