### PR TITLE
fix: edge case when attempting to pad title

### DIFF
--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -13,6 +13,11 @@ export const textWithPadding = (
   const leftPadding = Math.floor((columnLen - curTextSize) / 2);
   const rightPadding = columnLen - leftPadding - curTextSize;
 
+  // handle edge cases where the text size is larger than the column length
+  if (columnLen < curTextSize) {
+    return text;
+  }
+
   // console.log(text, columnLen, curTextSize);
   switch (alignment) {
     case 'left':

--- a/test/utils/string-utils.test.ts
+++ b/test/utils/string-utils.test.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { limitWidth } from '../../src/utils/string-utils';
+import { textWithPadding, limitWidth } from '../../src/utils/string-utils';
 
 describe('Example: Print a simple Table with cell colors', () => {
   it('cell colors are working', () => {
@@ -9,5 +9,9 @@ describe('Example: Print a simple Table with cell colors', () => {
     expect(
       limitWidth(chalk.bgMagenta('magenta'), chalk.bgMagenta('magenta').length)
     ).toMatchObject([chalk.bgMagenta('magenta')]);
+  });
+
+  it('should not pass negative numbers into string.repeat', () => {
+    expect(textWithPadding('How are you?', 'right', 8)).toEqual('How are you?');
   });
 });


### PR DESCRIPTION
## 👀What is this pr about?

[Issue Link](https://github.com/ayonious/console-table-printer/issues/415#issuecomment-1120077142)

## 🚀 Changes

### Fixed
- Fixed edge case where it calls string.repeat with a negative number


Resolves #415 