### PR TITLE
fix: Adding Better regex for ansi codes stripping from the string

### DIFF
--- a/src/utils/console-utils.ts
+++ b/src/utils/console-utils.ts
@@ -2,7 +2,7 @@ import { wcswidth } from 'simple-wcswidth';
 import { CharLengthDict } from '../models/common';
 
 /* eslint-disable no-control-regex */
-const colorRegex = /\x1b\[\d{1,3}(;\d+)*m/g; // \x1b[30m  \x1b[305m
+const colorRegex = /\x1b\[\d{1,3}(;\d{1,3})*m/g; // \x1b[30m \x1b[305m \x1b[38;5m
 
 const stripAnsi = (str: string): string => str.replace(colorRegex, '');
 

--- a/src/utils/console-utils.ts
+++ b/src/utils/console-utils.ts
@@ -2,7 +2,7 @@ import { wcswidth } from 'simple-wcswidth';
 import { CharLengthDict } from '../models/common';
 
 /* eslint-disable no-control-regex */
-const colorRegex = /\x1b\[\d{1,3}m/g; // \x1b[30m  \x1b[305m
+const colorRegex = /\x1b\[\d{1,3}(;\d+)*m/g; // \x1b[30m  \x1b[305m
 
 const stripAnsi = (str: string): string => str.replace(colorRegex, '');
 


### PR DESCRIPTION
Modified regex to allow for more variations of ansi codes like '\x1b[38;5m', bolding, etc.

## 👀What is this pr about?

Measurement of string width removes ansi escape codes for color, but only the ansi escape codes produced by the library. This change modifies the regex that strips escape codes for correct string width measurement to include more codes that can be inserted into the content text items by the caller.

## 🚀 Changes

### Updated

Width measurement regex

## 🖼 Screenshots

before:
┌───┬────┬───┐
│ a │  c │ b │
├───┼────┼───┤
│   1 │ 55 │   │
│   │    │ 1 │
└───┴────┴───┘

after:
┌───┬────┬───┐
│ a │  c │ b │
├───┼────┼───┤
│ 1 │ 55 │   │
│   │    │ 1 │
└───┴────┴───┘

## 👶 The naming of the PR

fix: ansi escape codes stripped better for measurement